### PR TITLE
feat: share string stored as b36

### DIFF
--- a/main.js
+++ b/main.js
@@ -93,7 +93,9 @@ $( "#submit" ).click(function () {
 
   small_milestone_date_output.innerHTML = small_milestone_date.toUTCString().substring(0, 16);
 
-  var share_link = "<a href='http://marbiru.github.io/days/share.html" + "?b=" + birthday + "'>here</a>";
+  birthday_b36 = birthday.toString(36);
+
+  var share_link = "<a href='http://marbiru.github.io/days/share.html" + "?b=" + birthday_b36 + "'>here</a>";
 
   share_link_output.innerHTML = share_link;
 

--- a/query.js
+++ b/query.js
@@ -10,7 +10,9 @@ function getParameterByName(name) {
 
 var mil_day = 86400000;
 
-var birthday = parseInt(getParameterByName( "b" ));
+var birthday_b36 = parseInt(getParameterByName( "b" ));
+
+var birthday = parseInt(birthday_b36, 36);
 
 var today_date = Date();
 


### PR DESCRIPTION
save a bit of space and make the urls look cooler by storing the query
parameter in b36 instead of decimal
